### PR TITLE
🔒 Add git-leaks pre-commit hook for secret detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0  # latest version
+    hooks:
+      - id: gitleaks
+        args: ['--verbose', '--redact']


### PR DESCRIPTION
## 🔒 Add Git-leaks Pre-commit Hook

This PR adds a pre-commit configuration with git-leaks to automatically detect and prevent commits containing secrets, API keys, passwords, and other sensitive information.

### What's Changed
- Added `.pre-commit-config.yaml` with git-leaks hook
- Configured git-leaks v8.28.0 with verbose and redacted output
- Pre-commit hooks are now installed and active

### Why This Matters
- **Security**: Prevents accidental commits of sensitive data
- **Compliance**: Ensures repository follows security best practices
- **Automation**: Runs automatically on every commit
- **Team Safety**: Protects all contributors from security mistakes

### How It Works
- Git-leaks scans all staged files before each commit
- If secrets are detected, the commit is blocked
- Verbose output shows what was found (redacted for security)
- Contributors can fix issues before committing

### Testing
✅ The setup has been tested and verified to work correctly
✅ Test commits containing secrets are properly blocked
✅ Normal commits without secrets proceed as expected

### Next Steps
After merging this PR:
1. All team members should run `pre-commit install` in their local repos
2. Existing secrets in the repository should be rotated if any are found
3. Consider running `gitleaks detect` on the entire repository history

This change enhances our security posture and helps maintain clean, secure code.